### PR TITLE
Play a random file, if multiple fitting sounds are found

### DIFF
--- a/Acoustics.moon
+++ b/Acoustics.moon
@@ -54,7 +54,7 @@ class Acoustics
       @@defaulUrl = @url if @url
 
   Play: =>
-    playSoundFile(@files[1], @volume) if @files and #@files > 0
+    playSoundFile(@files[math.random #@files], @volume) if @files and #@files > 0
 
   @argShortNamesToNames: (shortName) ->
     switch shortName


### PR DESCRIPTION
The specification says we should play one file at random, if multiple files are found with wildcards. This change implements that detail and does not need change when the "repeat" parameter is implemented.

Fixes #11